### PR TITLE
Wrap +1 and -1 ops in parens for pretty printed clarity

### DIFF
--- a/src/Lang/Common.hs
+++ b/src/Lang/Common.hs
@@ -41,8 +41,8 @@ instance Pretty Lit where
   pretty (I i) = pretty i
   pretty (B b) = pretty b
 instance Pretty Op where
-  pretty Add1 = P.key "+1"
-  pretty Sub1 = P.key "-1"
+  pretty Add1 = P.key "(+1)"
+  pretty Sub1 = P.key "(-1)"
   pretty IsNonNeg = P.key ">=0?"
 
 data VarLam n e = VarLam [n] e


### PR DESCRIPTION
Not sure how you'll feel about this, but seeing `-1 0` is less clear to me than `(-1) 0` in pretty printing - thoughts?